### PR TITLE
feat: type alias for field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -741,6 +741,11 @@ export function field(properties: SimpleField | CustomField<any>) {
 }
 
 /**
+ * Type alias for `field`
+ */
+export const borsh = field
+
+/**
  * @param clazzes
  * @param validate, run validation?
  * @returns Schema map


### PR DESCRIPTION
Decorator  name `field` maybe not specific enough, I think we can add a type alias for `field` named `borsh` that specifically refers to borsh serialization